### PR TITLE
fix: `nextWorkbook` と `prevWorkbook` の挙動を修正 #1

### DIFF
--- a/src/core/Util.bas
+++ b/src/core/Util.bas
@@ -160,6 +160,17 @@ Function reReplace(ByVal str As String, ByVal Pattern As String, ByVal replaceSt
     Set re = Nothing
 End Function
 
+Function getWorkbookIndex(ByVal targetWorkbook As Workbook) As Integer
+    Dim i As Integer
+
+    For i = 1 To Workbooks.Count
+        If Workbooks(i).FullName = targetWorkbook.FullName Then
+            getWorkbookIndex = i
+            Exit For
+        End If
+    Next i
+End Function
+
 '#####################################################################################'
 ' Source: https://mohayonao.hatenadiary.org/entry/20080617/1213712469                 '
 'vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv'

--- a/src/functions/UsefulCmd.bas
+++ b/src/functions/UsefulCmd.bas
@@ -237,31 +237,27 @@ End Function
 Function nextWorkbook()
     Dim i As Integer
 
-    With ActiveWindow
-        i = .Index - 1
-        Do
-            i = (i + 1) Mod Windows.Count
-            If Windows(i + 1).Visible Then
-                Windows(i + 1).Activate
-                Exit Function
-            End If
-        Loop
-    End With
+    i = getWorkbookIndex(ActiveWorkbook) - 1
+    Do
+        i = ((i + 1) Mod Workbooks.Count) + 1
+        If Windows(Workbooks(i).Name).Visible Then
+            Workbooks(i).Activate
+            Exit Function
+        End If
+    Loop
 End Function
 
 Function previousWorkbook()
     Dim i As Integer
 
-    With ActiveWindow
-        i = .Index - 1
-        Do
-            i = (i - 1 + Windows.Count) Mod Windows.Count
-            If Windows(i + 1).Visible Then
-                Windows(i + 1).Activate
-                Exit Function
-            End If
-        Loop
-    End With
+    i = getWorkbookIndex(ActiveWorkbook) - 1
+    Do
+        i = ((i - 1 + Workbooks.Count) Mod Workbooks.Count) + 1
+        If Windows(Workbooks(i).Name).Visible Then
+            Workbooks(i).Activate
+            Exit Function
+        End If
+    Loop
 End Function
 
 Function toggleReadOnly()


### PR DESCRIPTION
close #1