### PR TITLE
fix: infinite loop bug in `nextWorkbook` and `prevWorkbook` #21

### DIFF
--- a/src/core/Util.bas
+++ b/src/core/Util.bas
@@ -163,6 +163,11 @@ End Function
 Function getWorkbookIndex(ByVal targetWorkbook As Workbook) As Integer
     Dim i As Integer
 
+    If targetWorkbook Is Nothing Then
+        getWorkbookIndex = 0
+        Exit Function
+    End If
+
     For i = 1 To Workbooks.Count
         If Workbooks(i).FullName = targetWorkbook.FullName Then
             getWorkbookIndex = i

--- a/src/functions/UsefulCmd.bas
+++ b/src/functions/UsefulCmd.bas
@@ -234,28 +234,30 @@ End Function
 
 Function nextWorkbook()
     Dim i As Integer
+    Dim idx As Integer
 
-    i = getWorkbookIndex(ActiveWorkbook) - 1
-    Do
-        i = ((i + 1) Mod Workbooks.Count) + 1
-        If Windows(Workbooks(i).Name).Visible Then
-            Workbooks(i).Activate
+    idx = getWorkbookIndex(ActiveWorkbook)
+    For i = 1 To Workbooks.Count
+        idx = (idx Mod Workbooks.Count) + 1
+        If Windows(Workbooks(idx).Name).Visible Then
+            Workbooks(idx).Activate
             Exit Function
         End If
-    Loop
+    Next i
 End Function
 
 Function previousWorkbook()
     Dim i As Integer
+    Dim idx As Integer
 
-    i = getWorkbookIndex(ActiveWorkbook) - 1
-    Do
-        i = ((i - 1 + Workbooks.Count) Mod Workbooks.Count) + 1
-        If Windows(Workbooks(i).Name).Visible Then
-            Workbooks(i).Activate
+    idx = getWorkbookIndex(ActiveWorkbook)
+    For i = 1 To Workbooks.Count
+        idx = ((idx - 2 + Workbooks.Count) Mod Workbooks.Count) + 1
+        If Windows(Workbooks(idx).Name).Visible Then
+            Workbooks(idx).Activate
             Exit Function
         End If
-    Loop
+    Next i
 End Function
 
 Function toggleReadOnly()


### PR DESCRIPTION
- fix: index calculation error
- fix: infinite loop bug when all books are hidden